### PR TITLE
Don't exit 0 on wrong PID

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     // If we don't get any output, we probably have a faulty PID
     if String::from_utf8_lossy(&ps_out.stdout).is_empty() {
         println!("Got nothing from PID {}, nonexistent process?", pid);
-        exit(0);
+        exit(1);
     }
 
     let pstime = String::from_utf8_lossy(&ps_out.stdout);


### PR DESCRIPTION
We shouldn't exit with 0 (success) if we can't process the PID.